### PR TITLE
Apply OfflinePlugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1331,8 +1331,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1385,8 +1384,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1471,7 +1469,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -2368,8 +2365,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.1",
@@ -2746,8 +2742,7 @@
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "define-properties": {
       "version": "1.1.2",
@@ -2954,8 +2949,7 @@
     "ejs": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
-      "dev": true
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "electron-to-chromium": {
       "version": "1.3.34",
@@ -2987,8 +2981,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -6376,8 +6369,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -7232,7 +7224,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -7826,6 +7817,31 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
       "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
       "dev": true
+    },
+    "offline-plugin": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/offline-plugin/-/offline-plugin-5.0.3.tgz",
+      "integrity": "sha1-YUiMXFhC2Fdqpnc4S1u9PmCUkok=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ejs": "2.5.7",
+        "loader-utils": "0.2.17",
+        "minimatch": "3.0.4",
+        "slash": "1.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -10200,8 +10216,7 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mobx-react": "^4.4.1",
     "mobx-react-devtools": "^4.2.15",
     "mobx-utils": "^3.2.2",
+    "offline-plugin": "^5.0.3",
     "query-string": "^5.0.1",
     "react": "^16.2.0",
     "react-async-script": "^0.9.1",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,13 +7,14 @@ import * as ReactDOM from "react-dom";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import { App } from "./components/app";
 import * as dialogStyle from "./dialog.scss";
+import { PROD } from "./env";
 import { stores } from "./stores";
 
 (Dialog as any).defaultProps.className = dialogStyle.dialog;
 (Dialog as any).defaultProps.contentClassName = dialogStyle.dialogContent;
 
 // Installing ServiceWorker
-if ( process.env.__PROD__ )  {
+if ( PROD ) {
   OfflinePluginRuntime.install();
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import "core-js";
 import { Dialog } from "material-ui";
 import { Provider } from "mobx-react";
+import * as OfflinePluginRuntime from "offline-plugin/runtime";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
@@ -10,6 +11,11 @@ import { stores } from "./stores";
 
 (Dialog as any).defaultProps.className = dialogStyle.dialog;
 (Dialog as any).defaultProps.contentClassName = dialogStyle.dialogContent;
+
+// Installing ServiceWorker
+if ( process.env.__PROD__ )  {
+  OfflinePluginRuntime.install();
+}
 
 ReactDOM.render(
   <BrowserRouter>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require("webpack");
+const OfflinePlugin = require("offline-plugin");
 
 module.exports = {
     entry: [
@@ -15,7 +16,18 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             __PROD__: JSON.stringify(process.env.NODE_ENV === "PROD"),
-        })
+        }),
+        new OfflinePlugin({
+            caches: {
+                main: [":rest:"],
+            },
+            ServiceWorker: {
+                output: "sw.js",
+                publicPath: "/sw.js",
+                cacheName: "anontown",
+                minify: true,
+            },
+        }),
     ],
     module: {
         rules: [


### PR DESCRIPTION
Hi, thanks for developing Anontown. It's pretty awesome project.

But currently, the upstream seems to be loading its bundle file each time it was loaded

![2018-05-06 0 03 36](https://user-images.githubusercontent.com/19276905/39666493-0dbf81d2-50c2-11e8-88a9-c978456716c4.png)

Of course, the backend returns 304 so it's not actually loading every time, but the browser always wait for the response and it costs many seconds I guess.

Thus, this PR adds OfflinePlugin which stores bundle files locally w/ ServiceWorker and now it makes browser never try to fetch it so it reduces times 👍 

![2018-05-06 0 02 13](https://user-images.githubusercontent.com/19276905/39666519-80f7d2bc-50c2-11e8-8cf5-1067baa51c35.png)

> NOTE: Apply offline-plugin to `bundle.js` won't be loaded even if super-reload, so you'd better give hash with Webpack to `bundle.js` like `[chunkhash].js` to confirm bundle modified.